### PR TITLE
Fix module path when there are configurations

### DIFF
--- a/cmec-driver.py
+++ b/cmec-driver.py
@@ -670,7 +670,7 @@ def cmec_run(strModelDir, strWorkingDir, module_list, config_dir, strObsDir=""):
                 if str_configuration in ("", setting):
                     setting_path = cmec_toc.find(setting)
                     cmec_settings.ReadFromFile(setting_path)
-                    module_path_list.append(setting_path)
+                    module_path_list.append(setting_path.parents[0])
                     driver_script_list.append(module_path / cmec_settings.GetDriverScript())
                     working_dir_list.append(Path(cmec_toc.getName()) / Path(cmec_settings.GetName()))
                     config_found = True
@@ -742,7 +742,7 @@ def cmec_run(strModelDir, strWorkingDir, module_list, config_dir, strObsDir=""):
         env_scripts.append(path_script)
         print(str(path_script))
         # resolve paths for writing if they exist:
-        module_path_full = module_path.resolve()
+        module_path_full = mPath.resolve()
         modpath_full = modpath.resolve()
         working_full = path_working_dir.resolve()
         config_full = config_dir.resolve()


### PR DESCRIPTION
Summary:
Fixing a bug so that the correct path for the module configuration is grabbed and written to $CMEC_CODE_DIR in cmec_run.bash. When multiple modules were being run, this bug would cause the path for one module to be written as the $CMEC_CODE_DIR for other modules. 

Testing:
I've tested this version with running CyMeP (single configuration), PMP (same module, multiple configurations at once), and a prototype of PMP and ILAMB (different modules at once).