### PR TITLE
Add conda setup option

### DIFF
--- a/cmec-driver.py
+++ b/cmec-driver.py
@@ -4,6 +4,7 @@ CMEC driver
 Interface for running CMEC-compliant modules.
 
 Examples:
+
     Add conda source information::
 
     $ python cmec-driver.py setup -conda_source <path_to_conda>


### PR DESCRIPTION
A new function called "setup" is added to add and remove conda installation information from the .cmeclibrary file. CMEC driver creates two new environment variables, $CONDA_SOURCE and $CONDA_ENV_ROOT, in cmec_run.bash. CMEC packages can use these variables to automatically activate conda environments at runtime.

Examples of how to use the setup:

    Add conda source information::

    $ python cmec-driver.py setup -conda_source <path_to_conda_executable>
    $ python cmec-driver.py setup -conda_source ~/miniconda3/etc/profile.d/conda.sh

    Add environment directory::

    $ python cmec-driver.py setup -env_root <path_to_environments>
    $ python cmec-driver.py setup -env_root ~/miniconda3/envs

    Remove conda install information::

    $ python cmec-driver.py setup -clear_conda