### PR TITLE
Change default for output folder prompt

### DIFF
--- a/cmec-driver.py
+++ b/cmec-driver.py
@@ -59,7 +59,7 @@ cmec_toc_name = "contents.json"
 cmec_settings_name = "settings.json"
 
 
-def user_prompt(question, default = "yes"):
+def user_prompt(question, default = "no"):
     """Asks the user a yes/no question
 
     Args:


### PR DESCRIPTION
Cmec driver prompts the user to choose whether or not to overwrite the output directory if it already exists. The current default is "yes". On user request, the default is being changed to "no" so that if users hit the enter key, cmec-driver will exist without overwriting the output directory.