### PR TITLE
Display full path for log

### DIFF
--- a/cmec_driver/cmec_driver.py
+++ b/cmec_driver/cmec_driver.py
@@ -484,7 +484,7 @@ def cmec_run(strModelDir, strWorkingDir, module_list, config_file, strObsDir="")
             print("Module " + module + " failed with return code",p.returncode)
         else:
             print("Module " + module + " completed.")
-        print("See cmec-driver log: ",log_path.relative_to(Path.cwd()))
+        print("See cmec-driver log: ",log_path)
 
         # Do final work and clean-up
         if (path_out/"output.json").exists():

--- a/cmec_driver/cmec_global_vars.py
+++ b/cmec_driver/cmec_global_vars.py
@@ -3,7 +3,7 @@ cmec_global_vars.py
 These are global variables used throughout CMEC driver.
 "version" should be incremented with each new release.
 """
-version = "1.1.0"
+version = "1.1.1"
 cmec_library_name = ".cmeclibrary"
 cmec_config_dir = ".cmec"
 cmec_toc_name = "contents.json"


### PR DESCRIPTION
Since the output directory does not need to be a subfolder of the current directory, it should not be assumed that the log is in a subdirectory and can use a relative path. 