### PR TITLE
Fix TOC configuration removal

### DIFF
--- a/cmec_driver/cmec_driver.py
+++ b/cmec_driver/cmec_driver.py
@@ -173,6 +173,8 @@ def cmec_unregister(module_name, config_file):
 
     print("Removing configuration")
     module_dir = lib.find(module_name)
+    print(module_dir)
+    print(config_file)
     cmec_settings = CMECModuleSettings()
     cmec_toc = CMECModuleTOC()
     tmp_settings_name = cmec_settings.exists_in_module_path(module_dir)

--- a/cmec_driver/cmec_global_vars.py
+++ b/cmec_driver/cmec_global_vars.py
@@ -3,7 +3,7 @@ cmec_global_vars.py
 These are global variables used throughout CMEC driver.
 "version" should be incremented with each new release.
 """
-version = "1.1.1"
+version = "1.1.2"
 cmec_library_name = ".cmeclibrary"
 cmec_config_dir = ".cmec"
 cmec_toc_name = "contents.json"

--- a/cmec_driver/cmec_io.py
+++ b/cmec_driver/cmec_io.py
@@ -440,13 +440,13 @@ class CMECModuleTOC():
                 cmec_settings.read_from_file(path_settings)
                 cmec_settings.create_config(config_file, self.get_name(),mod_is_pod=mod_is_pod)
 
-    def remove_config(self, path_module):
+    def remove_config(self, config_file, path_module):
         for item in self.jcontents:
             if isinstance(item, str):
                 cmec_settings = CMECModuleSettings()
                 path_settings = path_module/item
                 cmec_settings.read_from_file(path_settings)
-                cmec_settings.remove_config(self.get_name())
+                cmec_settings.remove_config(config_file, self.get_name())
 
     def get_name(self):
         """Return the name of the module."""


### PR DESCRIPTION
Bugfix for cmec-driver unregister. When a module has multiple configurations, cmec-driver could not successfully unregister it. The TOC object's remove_config function has been updated to take the config_file as a variable and pass it to the settings file removal function.