### PR TITLE
Condense overwrite prompts

### DIFF
--- a/cmec_driver/cmec_global_vars.py
+++ b/cmec_driver/cmec_global_vars.py
@@ -3,7 +3,7 @@ cmec_global_vars.py
 These are global variables used throughout CMEC driver.
 "version" should be incremented with each new release.
 """
-version = "1.1.4"
+version = "1.1.5"
 cmec_library_name = ".cmeclibrary"
 cmec_config_dir = ".cmec"
 cmec_toc_name = "contents.json"

--- a/cmec_driver/cmec_io.py
+++ b/cmec_driver/cmec_io.py
@@ -288,10 +288,12 @@ class CMECModuleSettings():
         # load existing cmec config or create new config
         config_file = CMECConfig(config_file)
         config_file.read()
-        rewrite = user_prompt("Overwrite cmec.json?")
-        if not rewrite:
-            print("*** Skip writing default parameters. Warning: This may affect module performance. ***")
-            return
+        # Prompt if single configuration
+        if module_name == '':
+            rewrite = user_prompt("Overwrite cmec.json?")
+            if not rewrite:
+                print("*** Skip writing default parameters. Warning: This may affect module performance. ***")
+                return
         config_file.update(module_settings)
         config_file.write()
 
@@ -433,6 +435,10 @@ class CMECModuleTOC():
 
     def create_config(self, config_file, path_module, mod_is_pod=False):
         """Create module settings json for each configuration."""
+        rewrite = user_prompt("Overwrite cmec.json?")
+        if not rewrite:
+            print("*** Skip writing default parameters. Warning: This may affect module performance. ***")
+            return
         for item in self.jcontents:
             if isinstance(item, str):
                 cmec_settings = CMECModuleSettings()


### PR DESCRIPTION
During registration, cmec-driver would ask to overwrite the configuration file once per configuration. This becomes onerous for a module with multiple configurations. Now CMEC driver only prompts once for the entire module.