### PR TITLE
Create config directory if not present

### DIFF
--- a/cmec_driver/cmec_driver.py
+++ b/cmec_driver/cmec_driver.py
@@ -552,6 +552,9 @@ def main():
     # get the rest of the arguments
     args = parser.parse_args()
 
+    # config directory might not exist yet
+    Path(cmec_config_dir).mkdir(exist_ok=True)
+
     # cmec config goes in cmec-driver/config folder
     config_file = Path.home()/cmec_config_dir/"cmec.json"
 

--- a/cmec_driver/cmec_driver.py
+++ b/cmec_driver/cmec_driver.py
@@ -553,7 +553,7 @@ def main():
     args = parser.parse_args()
 
     # config directory might not exist yet
-    Path(cmec_config_dir).mkdir(exist_ok=True)
+    (Path.home()/cmec_config_dir).mkdir(exist_ok=True)
 
     # cmec config goes in cmec-driver/config folder
     config_file = Path.home()/cmec_config_dir/"cmec.json"


### PR DESCRIPTION
Hidden directory for user settings file needs to be explicitly created before writing settings file.

Closes #18 