### PR TITLE
Fix netCDF folder name for MDTF support

### DIFF
--- a/cmec_driver/cmec_driver.py
+++ b/cmec_driver/cmec_driver.py
@@ -388,7 +388,7 @@ def cmec_run(strModelDir, strWorkingDir, module_list, config_file, strObsDir="")
         # Create new output directories directories
         path_out.mkdir(parents=True)
         if module_dict[module]["mod_is_pod"]:
-            for folder in [path_out/"model"/"netcdf", path_out/"model"/"PS", path_out/"obs"/"netcdf", path_out/"obs"/"PS"]:
+            for folder in [path_out/"model"/"netCDF", path_out/"model"/"PS", path_out/"obs"/"netCDF", path_out/"obs"/"PS"]:
                 path_out_tmp = folder
                 path_out_tmp.mkdir(parents=True)
 

--- a/cmec_driver/cmec_global_vars.py
+++ b/cmec_driver/cmec_global_vars.py
@@ -4,7 +4,7 @@ These are global variables used throughout CMEC driver.
 "version" should be incremented with each new release.
 """
 
-version = "1.1.8"
+version = "1.1.9"
 cmec_library_name = ".cmeclibrary"
 cmec_config_dir = ".cmec"
 cmec_toc_name = "contents.json"

--- a/cmec_driver/mdtf_support.py
+++ b/cmec_driver/mdtf_support.py
@@ -239,12 +239,14 @@ def mdtf_file_cleanup(wk_dir,clear_ps,clear_nc):
     """Delete PS and netCDF if requested."""
     if clear_ps:
         print("Deleting postscript images.")
-        ps_dir = wk_dir/"model"/"PS"
-        remove_directory(ps_dir)
+        for dir_name in ["model","obs"]:
+            ps_dir = wk_dir/dir_name/"PS"
+            remove_directory(ps_dir)
     if clear_nc:
         print("Deleting intermediate netCDF files.")
-        nc_dir = wk_dir/"model"/"netcdf"
-        remove_directory(nc_dir)
+        for dir_name in ["model","obs"]:
+            nc_dir = wk_dir/dir_name/"netCDF"
+            remove_directory(nc_dir)
 
 def mdtf_settings_proc(module_dict,cmec_settings,module_path,str_configuration):
     module_path = Path(module_path)


### PR DESCRIPTION
MDTF PODs sometimes write intermediate files to the working directory. These files are placed in subfolders called "netCDF" under the "model" or "obs" directories. 

In the cmec-driver implementation, cmec-driver creates these folder before running the POD. The name of the netCDF folder has been incorrect, with cmec-driver creating a "netcdf" folder instead of "netCDF" (different capitalization). This causes errors on some file systems but not others. The name has been fixed in this PR.